### PR TITLE
option to use google cred as env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,27 @@
 This is a [Hubot](http://hubot.github.com/) adapter for [Hangouts Chat](https://gsuite.google.com/products/chat/).
 
 Documentation is available in [Google Developers site](https://developers.google.com/hangouts/chat/how-tos/integrate-hubot).
+
+
+## Loading credentials from environment variables
+
+  If you are running on Heroku you can't rely on a json file. You must have the json
+ available as a environment variable direclty. It is described [here](https://github.com/googleapis/google-auth-library-nodejs/blob/master/README.md#loading-credentials-from-environment-variables).
+
+  So instead of setting a `GOOGLE_APPLICATION_CREDENTIALS` environment variable you can
+ provide the json data inside `GOOGLE_APPLICATION_CREDENTIALS_DATA` like that:
+
+  ```
+ GOOGLE_APPLICATION_CREDENTIALS_DATA='{
+   "type": "service_account",
+   "project_id": "your-project-id",
+   "private_key_id": "your-private-key-id",
+   "private_key": "your-private-key",
+   "client_email": "your-client-email",
+   "client_id": "your-client-id",
+   "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+   "token_uri": "https://accounts.google.com/o/oauth2/token",
+   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+   "client_x509_cert_url": "your-cert-url"
+ }' node bot.js
+ ```

--- a/src/bot.js
+++ b/src/bot.js
@@ -31,10 +31,20 @@ class HangoutsChatBot extends Adapter {
     this.isPubSub = options.isPubSub;
     this.port = options.port;
 
+    let google_auth_params = {}
+
+    if(process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA) {
+       // Handle json file as a environement variable for Heroku like systems
+       google_auth_params = {
+           credentials: JSON.parse(process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA)
+       }
+     }
+
     // Establish OAuth with Hangouts Chat. This is required for PubSub bots and
     // HTTP bots which want to create async messages.
     const authClientPromise = auth.getClient({
-      scopes: ['https://www.googleapis.com/auth/chat.bot']
+      scopes: ['https://www.googleapis.com/auth/chat.bot'],
+      ...google_auth_params
     });
     this.chatPromise = authClientPromise.then((credentials) =>
       google.chat({
@@ -255,7 +265,7 @@ class HangoutsChatBot extends Adapter {
 
   /**
    * Sets up adapter for communicating with Hangouts Chat. Hubot invokes this
-   * message during initialization. Need to always respond otherwise you'll see the 
+   * message during initialization. Need to always respond otherwise you'll see the
    * "hubot is not responding" message in chat.
    */
   run() {


### PR DESCRIPTION
Hello

I am using a hubot  chatbot on a Google Hangouts Chat system and we are using it on a Heroku-like system, with no way to declare a `GOOGLE_APPLICATION_CREDENTIALS=cred.json`.

So I propose the following to allow using Heroku/Dokku/nameit, using the environment variable GOOGLE_APPLICATION_CREDENTIALS_DATA that contains the content of the json file. See the README file for more info.

Let me know if you need additional info !

Thanks for the adapter ! 