### PR TITLE
fix: modified google-auth usage to work with new version

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -19,7 +19,7 @@
 const {Adapter, User, TextMessage} = require.main.require('hubot/es2015');
 const {PubSub} = require(`@google-cloud/pubsub`);
 const {google} = require('googleapis');
-const {auth} = require('google-auth-library');
+const {GoogleAuth} = require('google-auth-library');
 const {HangoutsChatTextMessage, AddedToSpaceTextMessage, AddedToSpaceMessage, RemovedFromSpaceMessage, CardClickedMessage} = require('./message')
 
 class HangoutsChatBot extends Adapter {
@@ -33,9 +33,14 @@ class HangoutsChatBot extends Adapter {
 
     // Establish OAuth with Hangouts Chat. This is required for PubSub bots and
     // HTTP bots which want to create async messages.
-    const authClientPromise = auth.getClient({
-      scopes: ['https://www.googleapis.com/auth/chat.bot']
+    // Establish OAuth with Hangouts Chat. This is required for PubSub bots and
+    // HTTP bots which want to create async messages.
+    const auth = new GoogleAuth({
+      scopes: 'https://www.googleapis.com/auth/chat.bot',
     });
+
+    const authClientPromise = auth.getClient();
+  
     this.chatPromise = authClientPromise.then((credentials) =>
       google.chat({
         version: 'v1',


### PR DESCRIPTION
Following [my previous package update PR](https://github.com/googleworkspace/hubot-google-hangouts-chat/pull/56), I've noticed the usage of `google-auth` has changed slightly, resulting in an invalid credentials error.

This PR fixes that.

It also seems like the automation for this project is broken (no updated packages are being published, missing linting rules, etc). See my issue here: https://github.com/googleworkspace/hubot-google-hangouts-chat/issues/60